### PR TITLE
Enable environment configuration for mint art

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+VITE_ART_URL=https://example.com/nft.png
+VITE_APP_URL=https://example.com/
+VITE_CONTRACT_ADDRESS=0xYourContractAddress
+VITE_VECTOR_ID=0
+VITE_REFERRER_ADDRESS=0xYourReferrerAddress
+

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ This mini app demonstrates how to create a simple NFT minting experience within 
 
 ## Configuration
 
-To configure the mini app for your own NFT collection, edit the `src/config.ts` file. You'll need to set:
+To configure the mini app for your own NFT collection, copy `.env.example` to `.env` and update the values. These environment variables control the default image and contract details used in `src/config.ts`.
+
+Alternatively you can edit `src/config.ts` directly. You'll need to set:
 
 - Collection name and description
 - Image URL for the NFT

--- a/public/.well-known/farcaster.json
+++ b/public/.well-known/farcaster.json
@@ -7,9 +7,9 @@
   "frame": {
     "version": "1",
     "name": "Mint Demo",
-    "iconUrl": "https://mint-demo.replit.app/icon.png",
-    "homeUrl": "https://mint-demo.replit.app/",
-    "imageUrl": "https://mint-demo.replit.app/nft.png",
+    "iconUrl": "https://example.com/icon.png",
+    "homeUrl": "https://example.com/",
+    "imageUrl": "https://example.com/nft.png",
     "buttonTitle": "Mint",
     "splashImageUrl": "https://mint-demo.replit.app/icon.png",
     "splashBackgroundColor": "#eeccff"

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,11 +4,14 @@ import { base } from "viem/chains";
 /**
  * NFT Metadata Configuration
  */
+const DEFAULT_IMAGE_URL = "https://mint-demo.replit.app/nft.png";
+const DEFAULT_APP_URL = "https://mint-demo.replit.app/";
+
 export const mintMetadata = {
   name: "Mini App Mint Demo",
   description:
     "A simple example of an onchain action in a Farcaster mini app. Tap the button below to mint this image.",
-  imageUrl: "https://mint-demo.replit.app/nft.png",
+  imageUrl: process.env.VITE_ART_URL ?? DEFAULT_IMAGE_URL,
   creator: {
     name: "horsefacts.eth",
     fid: 3621,
@@ -25,7 +28,8 @@ export const mintMetadata = {
  * Contract Configuration
  */
 export const contractConfig = {
-  address: "0x8087039152c472Fa74F47398628fF002994056EA" as Address,
+  address: (process.env.VITE_CONTRACT_ADDRESS as Address) ??
+    ("0x8087039152c472Fa74F47398628fF002994056EA" as Address),
   chain: base,
   abi: [
     { inputs: [], name: "MintPaused", type: "error" },
@@ -74,8 +78,9 @@ export const contractConfig = {
       type: "event",
     },
   ] as const as Abi,
-  vectorId: 6506,
-  referrer: "0x075b108fC0a6426F9dEC9A5c18E87eB577D1346a" as Address,
+  vectorId: Number(process.env.VITE_VECTOR_ID ?? 6506),
+  referrer: (process.env.VITE_REFERRER_ADDRESS as Address) ??
+    ("0x075b108fC0a6426F9dEC9A5c18E87eB577D1346a" as Address),
 } as const;
 
 /**
@@ -83,13 +88,13 @@ export const contractConfig = {
  */
 export const embedConfig = {
   version: "next",
-  imageUrl: "https://mint-demo.replit.app/nft.png",
+  imageUrl: process.env.VITE_ART_URL ?? DEFAULT_IMAGE_URL,
   button: {
     title: "Mint",
     action: {
       type: "launch_frame",
       name: "NFT Mint",
-      url: "https://mint-demo.replit.app/",
+      url: process.env.VITE_APP_URL ?? DEFAULT_APP_URL,
     },
   },
 } as const;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- allow using environment variables for art and contract details
- document `.env` usage
- update Farcaster frame metadata
- provide example env file
- add Vite type reference

## Testing
- `pnpm build` *(passes)*
- `pnpm lint` *(fails: import order, formatting, CSS parsing)*

------
https://chatgpt.com/codex/tasks/task_e_683fe5b6053c832cb07ef1cba1cb92ad